### PR TITLE
Setup and register trust configurator reconciler controller

### DIFF
--- a/cmd/garden-shoot-trust-configurator/app/options/options.go
+++ b/cmd/garden-shoot-trust-configurator/app/options/options.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package options
+
+import (
+	"errors"
+	"net"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// Options contain the server options.
+type Options struct {
+	ResyncOptions  ResyncOptions
+	ServingOptions ServingOptions
+}
+
+// ServingOptions are options applied to the shoot trust configurator server.
+type ServingOptions struct {
+	Address string
+	Port    uint
+}
+
+// AddFlags adds server options to flagset
+func (o *ServingOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.Address, "address", "", "The IP address that the server will listen on. If unspecified all interfaces will be used.")
+	fs.UintVar(&o.Port, "port", 10443, "The port that the server will listen on.")
+}
+
+// Validate checks if options are valid.
+// Returns errors if the port is out of range or address is invalid.
+func (o *ServingOptions) Validate() []error {
+	var errs []error
+	if o.Port == 0 || o.Port > 65535 {
+		errs = append(errs, errors.New("--port must be between 1 and 65535"))
+	}
+	if o.Address != "" && net.ParseIP(o.Address) == nil {
+		errs = append(errs, errors.New("--address must be a valid IP address"))
+	}
+	return errs
+}
+
+// ApplyTo applies the options to the configuration.
+func (o *ServingOptions) ApplyTo(c *ServingConfig) error {
+	c.Address = net.JoinHostPort(o.Address, strconv.FormatUint(uint64(o.Port), 10))
+	return nil
+}
+
+// ResyncOptions holds options regarding the resync interval between reconciliations.
+type ResyncOptions struct {
+	Duration time.Duration
+}
+
+// AddFlags adds the [ResyncOptions] flags to the flagset.
+func (o *ResyncOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&o.Duration, "resync-period", time.Minute*30, "The period between reconciliations of cluster shoot trust configurator information.")
+}
+
+// Validate checks if options are valid.
+func (o *ResyncOptions) Validate() []error {
+	var errs []error
+	if o.Duration <= 0 {
+		errs = append(errs, errors.New("--resync-period must be positive"))
+	}
+	return errs
+}
+
+// ApplyTo applies the options to the configuration.
+func (o *ResyncOptions) ApplyTo(c *ResyncConfig) error {
+	c.Duration = o.Duration
+	return nil
+}
+
+// ResyncConfig holds configurations regarding the resync interval between reconciliations.
+type ResyncConfig struct {
+	Duration time.Duration
+}
+
+// NewOptions return options with default values.
+func NewOptions() *Options {
+	opts := &Options{
+		ResyncOptions:  ResyncOptions{},
+		ServingOptions: ServingOptions{},
+	}
+	return opts
+}
+
+// AddFlags adds server options to flagset
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	o.ServingOptions.AddFlags(fs)
+	o.ResyncOptions.AddFlags(fs)
+}
+
+// ApplyTo applies the options to the configuration.
+func (o *Options) ApplyTo(server *Config) error {
+	if err := o.ResyncOptions.ApplyTo(&server.Resync); err != nil {
+		return err
+	}
+
+	return o.ServingOptions.ApplyTo(&server.Serving)
+}
+
+// Validate checks if options are valid.
+func (o *Options) Validate() []error {
+	return slices.Concat(
+		o.ResyncOptions.Validate(),
+		o.ServingOptions.Validate(),
+	)
+}
+
+// Config has all the context to run the shoot trust configurator server.
+type Config struct {
+	Resync  ResyncConfig
+	Serving ServingConfig
+}
+
+// ServingConfig has the context to run an http server.
+type ServingConfig struct {
+	Address string
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,9 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
+	golang.org/x/time v0.12.0
+	k8s.io/apimachinery v0.33.4
+	k8s.io/client-go v0.33.4
 	k8s.io/component-base v0.33.4
 	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d
 	sigs.k8s.io/controller-runtime v0.21.0
@@ -158,7 +161,6 @@ require (
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
-	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect
@@ -175,10 +177,8 @@ require (
 	istio.io/client-go v1.25.1 // indirect
 	k8s.io/api v0.33.4 // indirect
 	k8s.io/apiextensions-apiserver v0.33.4 // indirect
-	k8s.io/apimachinery v0.33.4 // indirect
 	k8s.io/apiserver v0.33.4 // indirect
 	k8s.io/autoscaler/vertical-pod-autoscaler v1.4.1 // indirect
-	k8s.io/client-go v0.33.4 // indirect
 	k8s.io/code-generator v0.33.4 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect

--- a/internal/reconciler/add.go
+++ b/internal/reconciler/add.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package reconciler
+
+import (
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ControllerName is the name of the shoot trust configurator.
+const ControllerName = "shoot-trust-configurator"
+
+// AnnotationTrustedShoot is the annotation that marks a Shoot to be trusted in the Garden cluster.
+// TODO(theoddora): Add Annotation to gardener/gardener constants and use it afterwards
+const AnnotationTrustedShoot = "authentication.gardener.cloud/trusted"
+
+// SetupWithManager specifies how the controller is built
+// to watch Shoots with the "authentication.gardener.cloud/trusted" annotation set to "true"
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Client == nil {
+		r.Client = mgr.GetClient()
+	}
+
+	return builder.ControllerManagedBy(mgr).
+		Named(ControllerName).
+		For(&gardencorev1beta1.Shoot{}, builder.WithPredicates(shootPredicate())).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 50,
+			RateLimiter: workqueue.NewTypedMaxOfRateLimiter(
+				workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](5*time.Second, 2*time.Minute),
+				&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+			),
+		}).
+		Complete(r)
+}
+
+func shootPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return isRelevantShoot(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return isRelevantShootUpdate(e.ObjectOld, e.ObjectNew) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return isRelevantShoot(e.Object) },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}
+
+func isRelevantShoot(obj client.Object) bool {
+	shoot, ok := obj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return false
+	}
+	if shoot.Annotations == nil {
+		return false
+	}
+	if v, ok := shoot.Annotations[v1beta1constants.AnnotationAuthenticationIssuer]; ok &&
+		v != v1beta1constants.AnnotationAuthenticationIssuerManaged {
+		return false
+	}
+	// Specifies whether the Shoot should be registered as a trusted cluster in the Garden cluster.
+	if v, ok := shoot.Annotations[AnnotationTrustedShoot]; ok && v == "true" {
+		return true
+	}
+	return false
+}
+
+func isRelevantShootUpdate(oldObj, newObj client.Object) bool {
+	return isRelevantShoot(newObj) || isRelevantShoot(oldObj)
+}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -6,20 +6,27 @@ package reconciler
 
 import (
 	"context"
+	"time"
 
+	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// Reconciler reconciles
+// Reconciler reconciles shoot trust configurator information.
 type Reconciler struct {
 	Client client.Client
+	Log    logr.Logger
+
+	ResyncPeriod time.Duration
 }
 
-// Reconcile logic
-func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
-	log := logf.FromContext(ctx)
-	log.Info("Starting reconciliation")
+// Reconcile handles reconciliation requests for Shoots marked to be trusted in the Garden cluster.
+func (r *Reconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("shoot", req.NamespacedName)
+
+	log.Info("Reconciling")
+	defer log.Info("Reconcile finished")
+
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
- Adds Options config to cobra command
- Sets up reconclier contoller with controller-runtime manager
- Introduces a suggestion for the annotation that will trigger the trust configurator:

```yaml
authentication.gardener.cloud/trusted: true/false
```

**Which issue(s) this PR fixes**:
Setup reconciliation controller.

**Special notes for your reviewer**:
Verification:

```bash
make start

# Output
{"level":"info","ts":"2025-09-03T14:47:35.079+0300","msg":"Starting application","app":"garden-shoot-trust-configurator","version":"v0.1.0-dev"}
{"level":"info","ts":"2025-09-03T14:47:35.080+0300","msg":"Flag","name":"address","value":"","default":""}
{"level":"info","ts":"2025-09-03T14:47:35.080+0300","msg":"Flag","name":"help","value":"false","default":"false"}
{"level":"info","ts":"2025-09-03T14:47:35.080+0300","msg":"Flag","name":"kubeconfig","value":"","default":""}
{"level":"info","ts":"2025-09-03T14:47:35.080+0300","msg":"Flag","name":"port","value":"10443","default":"10443"}
{"level":"info","ts":"2025-09-03T14:47:35.080+0300","msg":"Flag","name":"resync-period","value":"30m0s","default":"30m0s"}
{"level":"info","ts":"2025-09-03T14:47:35.080+0300","msg":"Flag","name":"version","value":"false","default":"false"}
{"level":"info","ts":"2025-09-03T14:47:35.081+0300","logger":"controllers.shoot-trust-configurator","msg":"Setting up with manager","resyncPeriod":"30m0s"}
{"level":"info","ts":"2025-09-03T14:47:35.081+0300","msg":"starting server","name":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2025-09-03T14:47:35.082+0300","logger":"manager","msg":"Starting EventSource","controller":"shoot-trust-configurator","controllerGroup":"core.gardener.cloud","controllerKind":"Shoot","source":"kind source: *v1beta1.Shoot"}
{"level":"info","ts":"2025-09-03T14:47:35.203+0300","logger":"manager","msg":"Starting Controller","controller":"shoot-trust-configurator","controllerGroup":"core.gardener.cloud","controllerKind":"Shoot"}
{"level":"info","ts":"2025-09-03T14:47:35.203+0300","logger":"manager","msg":"Starting workers","controller":"shoot-trust-configurator","controllerGroup":"core.gardener.cloud","controllerKind":"Shoot","worker count":50}
```

Afterwards, adding the annotation to the local shoot cluster:
```bash
kubectl -n garden-local annotate shoot local authentication.gardener.cloud/trusted=true
```

Logs indicate:
```bash
{"level":"info","ts":"2025-09-03T14:50:58.107+0300","logger":"controllers.shoot-trust-configurator","msg":"Reconciling","shoot":{"name":"local","namespace":"garden-local"}}
{"level":"info","ts":"2025-09-03T14:50:58.107+0300","logger":"controllers.shoot-trust-configurator","msg":"Reconcile finished","shoot":{"name":"local","namespace":"garden-local"}}
```

CC: @dimityrmirchev @vpnachev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
