### PR TITLE
[Fix] Include `ENSURE_GARDENER_MOD` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+ENSURE_GARDENER_MOD         := $(shell go get github.com/gardener/gardener@$$(go list -m -f "{{.Version}}" github.com/gardener/gardener))
 GARDENER_HACK_DIR           := $(shell go list -m -f "{{.Dir}}" github.com/gardener/gardener)/hack
 NAME                        := garden-shoot-trust-configurator
 IMAGE                       := europe-docker.pkg.dev/gardener-project/public/gardener/$(NAME)
@@ -93,7 +94,8 @@ test-clean:
 	@bash $(GARDENER_HACK_DIR)/test-cover-clean.sh
 
 .PHONY: verify
-verify: check format test sast
+# TODO(theoddora): add test command after including unit/integration tests
+verify: check format sast
 
 .PHONY: verify-extended
 # TODO(theoddora): add test command after including unit/integration tests


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

Error which is caused by the missing ENSURE_GARDENER_MOD in Makefile. 
`GARDENER_HACK_DIR` can fail on clean environments like GitHub Actions because `GARDENER_HACK_DIR` relies on the Gardener module already being downloaded

**Which issue(s) this PR fixes**:
Github actions show an error:
```
bash: /hack/get-build-ld-flags.sh: No such file or directory
Makefile:20: /hack/tools.mk: No such file or directory
make: *** No rule to make target '/hack/tools.mk'.  Stop.
Error: Process completed with exit code 2.
```

**Special notes for your reviewer**:
N/A
CC: @dimityrmirchev @vpnachev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
