### PR TITLE
Add finalizer 'shoot-trust-configurator'

### DIFF
--- a/internal/reconciler/shoot/add.go
+++ b/internal/reconciler/shoot/add.go
@@ -25,6 +25,9 @@ const (
 	// ControllerName is the name of the shoot trust configurator.
 	ControllerName = "shoot-trust-configurator"
 
+	// FinalizerName is the finalizer that is added to shoots to ensure proper cleanup of the OIDC resource.
+	FinalizerName = "authentication.gardener.cloud/shoot-trust-configurator"
+
 	// AnnotationTrustedShoot is the annotation that marks a Shoot to be trusted in the Garden cluster.
 	AnnotationTrustedShoot = "authentication.gardener.cloud/trusted"
 )

--- a/internal/reconciler/shoot/reconciler.go
+++ b/internal/reconciler/shoot/reconciler.go
@@ -120,7 +120,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		return nil
 	}); err != nil {
-		log.Error(err, "Failed to create or update OIDC resource", "oidc", client.ObjectKeyFromObject(oidc))
 		return ctrl.Result{}, err
 	}
 
@@ -152,7 +151,6 @@ func (r *Reconciler) deleteOIDCResource(ctx context.Context, log logr.Logger, sh
 			log.Info("OIDC resource not found, nothing to do", "oidc", oidcObjectKey)
 			return nil
 		}
-		log.Error(err, "Failed to get OIDC resource", "oidc", oidcObjectKey)
 		return fmt.Errorf("failed to get OIDC: %w", err)
 	}
 
@@ -161,7 +159,6 @@ func (r *Reconciler) deleteOIDCResource(ctx context.Context, log logr.Logger, sh
 			log.Info("OIDC resource not found, nothing to do", "oidc", oidcObjectKey)
 			return nil
 		}
-		log.Error(err, "Failed to delete OIDC resource", "oidc", oidcObjectKey)
 		return fmt.Errorf("failed to delete OIDC: %w", err)
 	}
 	log.Info("Successfully deleted OIDC resource", "oidc", oidcObjectKey)

--- a/internal/reconciler/shoot/reconciler.go
+++ b/internal/reconciler/shoot/reconciler.go
@@ -130,11 +130,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 // handleDeletion handles the deletion of a shoot and its associated OIDC resource
 func (r *Reconciler) handleDeletion(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (ctrl.Result, error) {
-	if !controllerutil.ContainsFinalizer(shoot, FinalizerName) {
-		log.Info("Finalizer not present, nothing to clean up")
-		return reconcile.Result{}, nil
-	}
-
 	// Clean up the OIDC resource
 	if err := r.deleteOIDCResource(ctx, log, shoot); err != nil {
 		return ctrl.Result{}, err

--- a/internal/reconciler/shoot/reconciler.go
+++ b/internal/reconciler/shoot/reconciler.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -48,7 +49,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.Client.Get(ctx, req.NamespacedName, shoot); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Info("Object is gone, stop reconciling and clean up OIDC resource if it exists")
+			log.Info("Object is gone, stop reconciling")
 			// TODO(theoddora): We don't have the shoot object here, so we cannot pass it to deleteOIDC to construct the OIDC resource name.
 			// We can add a garbage collection mechanism to clean up old OIDC resources that are not referenced by any shoot anymore.
 			return reconcile.Result{}, nil
@@ -56,19 +57,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return reconcile.Result{}, fmt.Errorf("error retrieving shoot from store: %w", err)
 	}
 
+	if shoot.DeletionTimestamp != nil {
+		log.Info("Shoot is being deleted, cleaning up OIDC resource")
+		return r.handleDeletion(ctx, log, shoot)
+	}
+
 	if shoot.Annotations[v1beta1constants.AnnotationAuthenticationIssuer] != v1beta1constants.AnnotationAuthenticationIssuerManaged {
 		log.Info("Shoot does not have expected annotation or their value is not 'managed'", "annotation", v1beta1constants.AnnotationAuthenticationIssuer, "value", shoot.Annotations[v1beta1constants.AnnotationAuthenticationIssuer])
-		return r.deleteOIDC(ctx, log, shoot)
+		return r.handleDeletion(ctx, log, shoot)
 	}
 
 	if trusted, _ := strconv.ParseBool(shoot.Annotations[AnnotationTrustedShoot]); !trusted {
 		log.Info("Shoot does not have expected annotation or their value is not 'true', clean up OIDC resource", "annotation", AnnotationTrustedShoot, "value", shoot.Annotations[AnnotationTrustedShoot])
-		return r.deleteOIDC(ctx, log, shoot)
+		return r.handleDeletion(ctx, log, shoot)
 	}
 
-	if shoot.DeletionTimestamp != nil {
-		log.Info("Shoot is being deleted, clean up OIDC resource")
-		return r.deleteOIDC(ctx, log, shoot)
+	if !controllerutil.ContainsFinalizer(shoot, FinalizerName) {
+		log.Info("Adding finalizer")
+		if err := controllerutils.AddFinalizers(ctx, r.Client, shoot, FinalizerName); err != nil {
+			return ctrl.Result{}, fmt.Errorf("could not add finalizer to shoot: %w", err)
+		}
 	}
 
 	var issuerURL string
@@ -120,29 +128,49 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) deleteOIDC(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (ctrl.Result, error) {
+// handleDeletion handles the deletion of a shoot and its associated OIDC resource
+func (r *Reconciler) handleDeletion(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(shoot, FinalizerName) {
+		log.Info("Finalizer not present, nothing to clean up")
+		return reconcile.Result{}, nil
+	}
+
+	// Clean up the OIDC resource
+	if err := r.deleteOIDCResource(ctx, log, shoot); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Removing finalizer")
+	if err := controllerutils.RemoveFinalizers(ctx, r.Client, shoot, FinalizerName); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) deleteOIDCResource(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) error {
 	oidc := emptyOIDC(shoot)
 	oidcObjectKey := client.ObjectKeyFromObject(oidc)
 	err := r.Client.Get(ctx, oidcObjectKey, oidc)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("OIDC resource not found, nothing to do", "oidc", oidcObjectKey)
-			return reconcile.Result{}, nil
+			return nil
 		}
 		log.Error(err, "Failed to get OIDC resource", "oidc", oidcObjectKey)
-		return reconcile.Result{}, fmt.Errorf("failed to get OIDC: %w", err)
+		return fmt.Errorf("failed to get OIDC: %w", err)
 	}
 
 	if err := r.Client.Delete(ctx, oidc); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("OIDC resource not found, nothing to do", "oidc", oidcObjectKey)
-			return reconcile.Result{}, nil
+			return nil
 		}
 		log.Error(err, "Failed to delete OIDC resource", "oidc", oidcObjectKey)
-		return ctrl.Result{}, fmt.Errorf("failed to delete OIDC: %w", err)
+		return fmt.Errorf("failed to delete OIDC: %w", err)
 	}
 	log.Info("Successfully deleted OIDC resource", "oidc", oidcObjectKey)
-	return reconcile.Result{}, nil
+	return nil
 }
 
 func emptyOIDC(shoot *gardencorev1beta1.Shoot) *authenticationv1alpha1.OpenIDConnect {

--- a/internal/reconciler/shoot/reconciler_test.go
+++ b/internal/reconciler/shoot/reconciler_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Reconciler", func() {
 
 	It("should delete OIDC resource because shoot is being deleted", func() {
 		// Adding a finalizer to simulate that the shoot is being deleted and not yet fully deleted to trigger the shoot.DeletionTimestamp check
-		// Additionally, the trust-configurator finalizer was not added yet, however we want to ensure that the OIDC resource is deleted
+		// Even if the trust-configurator finalizer is missing, we want to ensure that the OIDC resource is deleted
 		shoot.Finalizers = []string{"some/finalizer"}
 		Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
 		// Create OIDC resource that should be deleted


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
When a Shoot is deleted or the Shoot designates that it no longer requires to be trusted by the Garden cluster the corresponding OpenIDConnect should be deleted. Add a finalizer to the shoot which has managed issuer and has the trust annotation enabled. 

**Which issue(s) this PR fixes**:
Part of #23 

**Special notes for your reviewer**:
Verified using `make verify-extended`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
