### PR TITLE
chore(deps): add allowed deps for sigs.k8s.io and golang.org

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,7 +15,9 @@ updates:
     - dependency-name: "github.com/gardener/gardener/pkg/apis"
     - dependency-name: "github.com/gardener/oidc-webhook-authenticator"
     - dependency-name: "k8s.io/.*"
-    - dependency-name: "sigs.k8s.io/controller-runtime"
+    - dependency-name: "sigs.k8s.io/.*"
+    - dependency-name: "golang.org/x/.*"
+    - dependency-name: "github.com/go-jose/.*"
     groups:
       gardener:
         patterns:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
dependabot: Allow more gomod deps to be updated

**Which issue(s) this PR fixes**:
Similar to: https://github.com/gardener/oidc-webhook-authenticator/pull/241

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
