### PR TITLE
[gha] Use 'stable' go version for the setup-go action

### DIFF
--- a/.github/actions/prepare-release/action.yaml
+++ b/.github/actions/prepare-release/action.yaml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.26'
+        go-version: stable
     - name: prepare-release
       shell: bash
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: stable
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
       - name: run-verify


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
Use 'stable' go version for the setup-go action. This is helpful when the go toolchain version is changed, e.g. in go.mod, then the gh action does not need to be explicitly updated. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
