### PR TITLE
Adapt VPA resources to explicitly specify update mode `InPlaceOrRecreate`

### DIFF
--- a/charts/garden-shoot-trust-configurator/charts/runtime/values.yaml
+++ b/charts/garden-shoot-trust-configurator/charts/runtime/values.yaml
@@ -69,4 +69,4 @@ vpa:
     minAllowed:
       memory: 64Mi
   updatePolicy:
-    updateMode: "Recreate"
+    updateMode: "InPlaceOrRecreate"

--- a/charts/garden-shoot-trust-configurator/values.yaml
+++ b/charts/garden-shoot-trust-configurator/values.yaml
@@ -94,4 +94,4 @@ runtime:
       minAllowed:
         memory: 64Mi
     updatePolicy:
-      updateMode: "Recreate"
+      updateMode: "InPlaceOrRecreate"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
Gardener's `VPAInPlaceUpdates` feature gate has been promoted and unconditionally enabled. This unconditionally enables the Gardener Resource
  Manager's `vpa-in-place-updates` admission webhook, which was previously mutating the value from `Recreate` to `InPlaceOrRecreate` at admission
  time. This change makes the extension explicitly set the correct value, aligning the code with the actual runtime behavior and removing the implicit
  dependency on the webhook mutation.

**Which issue(s) this PR fixes**:

Part of gardener/gardener#12955

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The update mode of the VerticalPodAutoscaler resources deployed by the garden-shoot-trust-configurator is now explicitly set to `InPlaceOrRecreate`, reflecting the actual runtime behavior after the unconditional enablement of the `VPAInPlaceUpdates` feature gate.
```
